### PR TITLE
install apparmor package to resolve docker issue

### DIFF
--- a/cloud-config/docker_runner.yml
+++ b/cloud-config/docker_runner.yml
@@ -3,6 +3,7 @@ runcmd:
   - echo 'CI_MASTER_SSHKEY' >> /root/.ssh/authorized_keys
   - curl -L https://get.docker.com | bash
   - curl -L https://packages.gitlab.com/install/repositories/runner/gitlab-runner/script.deb.sh | bash
+  - apt-get install -y apparmor
   - apt-get install -y gitlab-runner
   - export CI_SERVER_URL='CI_REGISTRATION_URL'
   - export REGISTRATION_TOKEN=CI_REGISTRATION_TOKEN


### PR DESCRIPTION
As stated in this comment, currently docker has issues running on latest debian-based machines (not only debian). This can be fixed by installing apparmor package and restarting the docker service.